### PR TITLE
GET /api/postsの作成とテストの追加

### DIFF
--- a/api-and-rspec-training/Gemfile
+++ b/api-and-rspec-training/Gemfile
@@ -47,6 +47,7 @@ group :development, :test do
   gem 'rubocop-rspec'
   gem 'rspec-rails', '~> 7.0.0'
   gem 'annotate'
+  gem 'faker'
 end
 
 

--- a/api-and-rspec-training/Gemfile.lock
+++ b/api-and-rspec-training/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
@@ -313,6 +315,7 @@ DEPENDENCIES
   brakeman
   debug
   factory_bot_rails
+  faker
   jbuilder
   kaminari
   pry-rails

--- a/api-and-rspec-training/app/controllers/api/posts_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/posts_controller.rb
@@ -1,0 +1,9 @@
+class Api::PostsController < ApplicationController
+  def index
+    
+  end
+
+  def show
+
+  end
+end

--- a/api-and-rspec-training/app/controllers/api/posts_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/posts_controller.rb
@@ -1,6 +1,9 @@
 class Api::PostsController < ApplicationController
+  before_action :authenticate_user! # セッションを保持しているかアクションの前に確認
+
   def index
-    
+    posts = Post.all
+    render json: posts, status: :ok
   end
 
   def show

--- a/api-and-rspec-training/app/helpers/api/posts_helper.rb
+++ b/api-and-rspec-training/app/helpers/api/posts_helper.rb
@@ -1,0 +1,2 @@
+module Api::PostsHelper
+end

--- a/api-and-rspec-training/app/models/post.rb
+++ b/api-and-rspec-training/app/models/post.rb
@@ -1,0 +1,3 @@
+class Post < ApplicationRecord
+  belongs_to :user
+end

--- a/api-and-rspec-training/app/models/user.rb
+++ b/api-and-rspec-training/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :posts, dependent: :destroy
+
   validates :username, presence: true, uniqueness: true
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }

--- a/api-and-rspec-training/config/application.rb
+++ b/api-and-rspec-training/config/application.rb
@@ -6,6 +6,9 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# テストデータを日本語に設定
+Faker::Config.locale = :ja
+
 module ApiAndRspecTraining
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/api-and-rspec-training/config/routes.rb
+++ b/api-and-rspec-training/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     post "login", to: "sessions#create"
     resources :users, only: [:show]
+    resources :posts, only: [:index, :show]
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/api-and-rspec-training/db/migrate/20241104051330_create_posts.rb
+++ b/api-and-rspec-training/db/migrate/20241104051330_create_posts.rb
@@ -1,0 +1,11 @@
+class CreatePosts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :posts do |t|
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :posts, [:user_id, :created_at]
+  end
+end

--- a/api-and-rspec-training/db/schema.rb
+++ b/api-and-rspec-training/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_03_081203) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_04_051330) do
+  create_table "posts", force: :cascade do |t|
+    t.text "content", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "created_at"], name: "index_posts_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "username", null: false
     t.string "password_digest"
@@ -18,4 +27,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_03_081203) do
     t.datetime "updated_at", null: false
     t.index ["username"], name: "index_users_on_username", unique: true
   end
+
+  add_foreign_key "posts", "users"
 end

--- a/api-and-rspec-training/spec/factories/posts.rb
+++ b/api-and-rspec-training/spec/factories/posts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :post do
+    content { "MyText" }
+    user { nil }
+  end
+end

--- a/api-and-rspec-training/spec/factories/posts.rb
+++ b/api-and-rspec-training/spec/factories/posts.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :post do
-    content { "MyText" }
-    user { nil }
+    content { Faker::Lorem.paragraph(sentence_count: 10) }
   end
 end

--- a/api-and-rspec-training/spec/helpers/api/posts_helper_spec.rb
+++ b/api-and-rspec-training/spec/helpers/api/posts_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::PostsHelper. For example:
+#
+# describe Api::PostsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::PostsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/api-and-rspec-training/spec/models/post_spec.rb
+++ b/api-and-rspec-training/spec/models/post_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/api-and-rspec-training/spec/requests/api/posts_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/posts_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Posts", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/api-and-rspec-training/spec/requests/api/posts_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/posts_spec.rb
@@ -1,7 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe "Api::Posts", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let!(:user) { FactoryBot.create(:user)}
+  let!(:other_user_id) { 9999 }
+
+  context "セッションで認証されている場合" do
+    before do
+      post "/api/login", params: { username: user.username, password: user.password }  # 事前にログインをしておく
+    end
+
+    it "投稿が存在する場合、ステータスは200ですべての投稿を返す" do
+      FactoryBot.create_list(:post, 10, user: user)
+
+      get "/api/posts"
+      expect(response).to have_http_status(:ok)
+
+      json_response = JSON.parse(response.body)
+      expect(json_response.length).to eq(10)
+      json_response.each do | post |
+        expect(post["content"]).to be_present # contentが空でないかチェック
+      end
+    end
+
+    it "投稿が存在しない場合、ステータスは200で空の配列を返す" do
+      get "/api/posts"
+      expect(response).to have_http_status(:ok)
+
+      json_response = JSON.parse(response.body)
+      expect(json_response.length).to eq(0)
+    end
+  end
+
+  context "セッションで認証されていない場合" do
+    it "ステータスは401で認証エラーメッセージを返す" do
+      get "/api/posts"
+  
+      expect(response).to have_http_status(:unauthorized)
+      expect(JSON.parse(response.body)).to eq("error" => "認証されていないアクセスです。")
+    end
   end
 end

--- a/api-and-rspec-training/spec/requests/api/users_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/users_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Api::Users", type: :request do
   end
 
   context "セッションで認証されていない場合" do
-    it "認証エラーメッセージと401を返す" do
+    it "ステータスは401で認証エラーメッセージを返す" do
       get "/api/users/#{user.id}"
   
       expect(response).to have_http_status(:unauthorized)


### PR DESCRIPTION
下記手順で実装いたしました。

1. Postモデル、コントローラーの追加、ルーティングの設定
2. すべての投稿を取得し、Jsonで返す
3. セッションの認証を追加
4. テストデータとテストの作成

■ テストケース
▼ セッションで認証されている場合
投稿が存在する場合、ステータスは200ですべての投稿を返す
投稿が存在しない場合、ステータスは200で空の配列を返す

▼ セッションで認証されていない場合
ステータスは401で認証エラーメッセージを返す