### PR TITLE
GET /api/posts/{id}の作成とテストの作成

### DIFF
--- a/api-and-rspec-training/app/controllers/api/posts_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/posts_controller.rb
@@ -7,6 +7,11 @@ class Api::PostsController < ApplicationController
   end
 
   def show
+    post = Post.find(params[:id])
+    render json: post, status: :ok
 
+    # 例外処理（findは、値が取得できなかった場合にActiveRecord::RecordNotFoundを返す）
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "該当する投稿が見つかりませんでした。" }, status: :not_found
   end
 end

--- a/api-and-rspec-training/spec/requests/api/posts_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/posts_spec.rb
@@ -3,40 +3,77 @@ require 'rails_helper'
 RSpec.describe "Api::Posts", type: :request do
   let!(:user) { FactoryBot.create(:user)}
   let!(:other_user_id) { 9999 }
+  let!(:other_user_post_id) { 9999 }
 
-  context "セッションで認証されている場合" do
-    before do
-      post "/api/login", params: { username: user.username, password: user.password }  # 事前にログインをしておく
-    end
+  describe "GET /api/posts/" do
+    context "セッションで認証されている場合" do
+      before do
+        post "/api/login", params: { username: user.username, password: user.password }  # 事前にログインをしておく
+      end
+      
+      it "投稿が存在する場合、ステータスは200ですべての投稿を返す" do
+        FactoryBot.create_list(:post, 10, user: user)
 
-    it "投稿が存在する場合、ステータスは200ですべての投稿を返す" do
-      FactoryBot.create_list(:post, 10, user: user)
+        get "/api/posts"
+        expect(response).to have_http_status(:ok)
 
-      get "/api/posts"
-      expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response.length).to eq(10)
+        json_response.each do | post |
+          expect(post["content"]).to be_present # contentが空でないかチェック
+        end
+      end
 
-      json_response = JSON.parse(response.body)
-      expect(json_response.length).to eq(10)
-      json_response.each do | post |
-        expect(post["content"]).to be_present # contentが空でないかチェック
+      it "投稿が存在しない場合、ステータスは200で空の配列を返す" do
+        get "/api/posts"
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response.length).to eq(0)
       end
     end
 
-    it "投稿が存在しない場合、ステータスは200で空の配列を返す" do
-      get "/api/posts"
-      expect(response).to have_http_status(:ok)
-
-      json_response = JSON.parse(response.body)
-      expect(json_response.length).to eq(0)
+    context "セッションで認証されていない場合" do
+      it "ステータスは401で認証エラーメッセージを返す" do
+        get "/api/posts"
+    
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to eq("error" => "認証されていないアクセスです。")
+      end
     end
   end
 
-  context "セッションで認証されていない場合" do
-    it "ステータスは401で認証エラーメッセージを返す" do
-      get "/api/posts"
-  
-      expect(response).to have_http_status(:unauthorized)
-      expect(JSON.parse(response.body)).to eq("error" => "認証されていないアクセスです。")
+  describe "GET /api/posts/{id}" do
+    let!(:user_post) { FactoryBot.create(:post, user: user)}
+    context "セッションで認証されている場合" do
+      before do
+        post "/api/login", params: { username: user.username, password: user.password }  # 事前にログインをしておく
+      end
+
+      it "投稿が存在する場合、ステータスは200で投稿の情報を返す" do
+        get "/api/posts/#{user_post.id}"
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["id"]).to eq(user_post.id)
+        expect(json_response["content"]).to eq(user_post.content)
+      end
+
+      it "存在しない投稿ののIDをリクエストすると404を返す" do
+        get "/api/posts/#{other_user_post_id}"
+
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to eq("error" => "該当する投稿が見つかりませんでした。")
+      end
+    end
+
+    context "セッションで認証されていない場合" do
+      it "ステータスは401で認証エラーメッセージを返す" do
+        get "/api/posts/#{user_post.id}"
+        
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to eq("error" => "認証されていないアクセスです。")
+      end
     end
   end
 end


### PR DESCRIPTION
下記手順で実装いたしました。

1. 投稿IDから投稿の取得、JSONで投稿情報を返す
2. セッションの認証を追加
3. 認証できているか確認
4. できていない場合は、例外処理を使い、エラーメッセージを404で返す
5. テストを作成

■ テストケース
▼ セッションで認証されている場合
投稿が存在する場合、ステータスは200で投稿の情報を返す
投稿が存在しない場合、ステータスは404でエラーメッセージを返す

▼ セッションで認証されていない場合
ステータスは401で認証エラーメッセージを返す