### PR TITLE
POST /api/postsの作成とテストの作成

### DIFF
--- a/api-and-rspec-training/app/controllers/api/posts_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/posts_controller.rb
@@ -1,6 +1,13 @@
 class Api::PostsController < ApplicationController
   before_action :authenticate_user! # セッションを保持しているかアクションの前に確認
 
+  # 例外処理 JSON以外のリクエストが来たときの場合
+  rescue_from ActionDispatch::Http::Parameters::ParseError, with: :handle_parse_error
+  # 例外処理 パラメータが不正なリクエストの場合
+  rescue_from ActionController::ParameterMissing, with: :handle_parameter_missing
+  # 例外処理（findは、値が取得できなかった場合にActiveRecord::RecordNotFoundを返す）
+  rescue_from ActiveRecord::RecordNotFound, with: :handle_record_not_found
+
   def index
     posts = Post.all
     render json: posts, status: :ok
@@ -9,13 +16,14 @@ class Api::PostsController < ApplicationController
   def show
     post = Post.find(params[:id])
     render json: post, status: :ok
-
-    # 例外処理（findは、値が取得できなかった場合にActiveRecord::RecordNotFoundを返す）
-    rescue ActiveRecord::RecordNotFound
-      render json: { error: "該当する投稿が見つかりませんでした。" }, status: :not_found
   end
 
   def create
+    # post_params[:content] が存在しない（空）場合、エラーレスポンスを返す
+    if post_params[:content].blank?
+      return render json: { error: "投稿内容が空です。" }, status: :unprocessable_entity
+    end
+
     user_post = current_user.posts.build(post_params)
 
     if user_post.save
@@ -30,5 +38,17 @@ class Api::PostsController < ApplicationController
 
     def post_params
       params.require(:post).permit(:content)
+    end
+
+    def handle_parse_error(exception)
+      render json: { error: "リクエストはJSON形式である必要があります。" }, status: :bad_request
+    end
+
+    def handle_parameter_missing(exception)
+      render json: { error: "不正なリクエストであるため、投稿できませんでした。" }, status: :unprocessable_entity
+    end
+
+    def handle_record_not_found(exception)
+      render json: { error: "該当する投稿が見つかりませんでした。" }, status: :not_found
     end
 end

--- a/api-and-rspec-training/app/controllers/api/posts_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/posts_controller.rb
@@ -14,4 +14,21 @@ class Api::PostsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       render json: { error: "該当する投稿が見つかりませんでした。" }, status: :not_found
   end
+
+  def create
+    user_post = current_user.posts.build(post_params)
+
+    if user_post.save
+      render json: user_post, status: :ok
+    else
+      render json: { error: "投稿できませんでした" }, status: :unprocessable_entity
+    end
+  end
+
+
+  private
+
+    def post_params
+      params.require(:post).permit(:content)
+    end
 end

--- a/api-and-rspec-training/app/controllers/api/posts_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/posts_controller.rb
@@ -21,7 +21,7 @@ class Api::PostsController < ApplicationController
     if user_post.save
       render json: user_post, status: :ok
     else
-      render json: { error: "投稿できませんでした" }, status: :unprocessable_entity
+      render json: { error: "投稿できませんでした。" }, status: :unprocessable_entity
     end
   end
 

--- a/api-and-rspec-training/app/controllers/application_controller.rb
+++ b/api-and-rspec-training/app/controllers/application_controller.rb
@@ -7,4 +7,11 @@ class ApplicationController < ActionController::API
       render json: { error: "認証されていないアクセスです。"}, status: :unauthorized
     end
   end
+
+  def current_user
+    if (user_id = session[:user_id]) # 代入と評価を同時にやっている
+      user = User.find_by(id: user_id)
+      @current_user ||= User.find_by(id: user_id) # find_byを実行するまでに、すでに@current_userに値がないが確認し、値があればそれを返す。
+    end
+  end
 end

--- a/api-and-rspec-training/app/models/post.rb
+++ b/api-and-rspec-training/app/models/post.rb
@@ -1,3 +1,5 @@
 class Post < ApplicationRecord
   belongs_to :user
+  validates :user_id, presence: true
+  validates :content, presence: true
 end

--- a/api-and-rspec-training/config/routes.rb
+++ b/api-and-rspec-training/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     post "login", to: "sessions#create"
     resources :users, only: [:show]
-    resources :posts, only: [:index, :show]
+    resources :posts, only: [:index, :show, :create]
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/api-and-rspec-training/spec/requests/api/posts_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/posts_spec.rb
@@ -103,15 +103,23 @@ RSpec.describe "Api::Posts", type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
 
         json_response = JSON.parse(response.body)
-        expect(json_response).to eq("error" => "投稿できませんでした。")
+        expect(json_response).to eq("error" => "投稿内容が空です。")
       end
 
-      it "空のリクエストボディでのリクエストの場合、422ステータスを返し、エラーメッセージを返す" do
-        post "/api/posts", params: { post: {} }
+      it "空のpostオブジェクトを送信した場合、422ステータスを返し、エラーメッセージを返す" do
+        post "/api/posts", params: { post: {} }, as: :json
         expect(response).to have_http_status(:unprocessable_entity)
 
         json_response = JSON.parse(response.body)
-        expect(json_response).to eq("error" => "投稿できませんでした。")
+        expect(json_response).to eq("error" => "不正なリクエストであるため、投稿できませんでした。")
+      end
+
+      it "不正なキーでリクエストした場合、422ステータスを返し、エラーメッセージを返す" do
+        post "/api/posts", params: { invalid_key: { content: "Content" } }
+  
+        expect(response).to have_http_status(:unprocessable_entity)
+        json_response = JSON.parse(response.body)
+        expect(json_response).to eq("error" => "不正なリクエストであるため、投稿できませんでした。")
       end
     end
 

--- a/api-and-rspec-training/spec/requests/api/posts_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/posts_spec.rb
@@ -76,4 +76,54 @@ RSpec.describe "Api::Posts", type: :request do
       end
     end
   end
+
+  describe "POST /api/posts/" do
+    let!(:user_post) { FactoryBot.create(:post, user: user)}
+    context "セッションで認証されている場合" do
+      before do
+        post "/api/login", params: { username: user.username, password: user.password }  # 事前にログインをしておく
+      end
+      it "正しいリクエストの場合、200ステータスと保存した投稿情報を返す" do
+        valid_post = FactoryBot.build(:post, content: "正しいリクエスト投稿です", user: user)
+        post "/api/posts", params: { post: { content: valid_post.content } }
+
+        expect(valid_post).to be_valid
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to have_key("id")
+        expect(json_response["content"]).to eq(valid_post.content)
+      end
+
+      it "contentが空のリクエストの場合、422ステータスを返し、エラーメッセージを返す" do
+        invalid_post = FactoryBot.build(:post, content: nil, user: user)
+        post "/api/posts", params: { post: { content: invalid_post.content } }
+
+        expect(invalid_post).not_to be_valid
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to eq("error" => "投稿できませんでした。")
+      end
+
+      it "空のリクエストボディでのリクエストの場合、422ステータスを返し、エラーメッセージを返す" do
+        post "/api/posts", params: { post: {} }
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to eq("error" => "投稿できませんでした。")
+      end
+    end
+
+    context "セッションで認証されていない場合" do
+      it "ステータスは401で認証エラーメッセージを返す" do
+        post "/api/posts", params: { content: user_post.content }
+    
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to eq("error" => "認証されていないアクセスです。")
+      end
+    end
+
+
+  end
 end


### PR DESCRIPTION
下記手順で実装いたしました。

1. セッションが保持できている場合は、current_userとしてユーザ情報を返す
2. current_userがストロングパラメータを使い、新しく投稿を作成し、データベースに保存させる
3. 2で保存できなかった場合に422ステータスとエラーメッセージを返す。
4. テストを作成
5. テストケースにそって、例外処理を追加

■ テストケース
▼ セッションで認証されている場合
正しいリクエストの場合、200ステータスと保存した投稿情報を返す
contentが空のリクエストの場合、422ステータスを返し、エラーメッセージを返す
空のpostオブジェクトを送信した場合、422ステータスを返し、エラーメッセージを返す
不正なキーでリクエストした場合、422ステータスを返し、エラーメッセージを返す

▼ セッションで認証されていない場合
ステータスは401で認証エラーメッセージを返す