### PR TITLE
POST /api/posts/{id}/likeの作成とテストの作成

### DIFF
--- a/api-and-rspec-training/app/controllers/api/likes_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/likes_controller.rb
@@ -2,13 +2,14 @@ class Api::LikesController < ApplicationController
   before_action :authenticate_user! # セッションを保持しているかアクションの前に確認
 
   def create
-    post = Post.find(params[:id])
-    like = post.likes.build(user:current_user)
+    post = Post.find(params[:post_id])
+    like = post.likes.build(user: current_user)
+  
 
     if like.save
-      render json: { message: "いいねしました。"}, status: :ok
+      render json: { message: "いいねしました。" }, status: :ok
     else
-      render json: { error: "すでにいいね済みです。"}, status: :unprocessable_entity
+      render json: { error: "すでにいいね済みです。" }, status: :unprocessable_entity
     end
 
     rescue ActiveRecord::RecordNotFound

--- a/api-and-rspec-training/app/controllers/api/likes_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/likes_controller.rb
@@ -1,0 +1,17 @@
+class Api::LikesController < ApplicationController
+  before_action :authenticate_user! # セッションを保持しているかアクションの前に確認
+
+  def create
+    post = Post.find(params[:id])
+    like = post.likes.build(user:current_user)
+
+    if like.save
+      render json: { message: "いいねしました。"}, status: :ok
+    else
+      render json: { error: "すでにいいね済みです。"}, status: :unprocessable_entity
+    end
+
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "該当する投稿が見つかりませんでした。" }, status: :not_found
+  end
+end

--- a/api-and-rspec-training/app/models/like.rb
+++ b/api-and-rspec-training/app/models/like.rb
@@ -1,0 +1,5 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+  validates :user_id, uniqueness: { scope: :post_id }  # 同じ投稿に対して一人のユーザーが複数回「いいね」しないようにする
+end

--- a/api-and-rspec-training/app/models/post.rb
+++ b/api-and-rspec-training/app/models/post.rb
@@ -1,5 +1,9 @@
 class Post < ApplicationRecord
   belongs_to :user
+  has_many :likes, dependent: :destroy
+  has_many :liked_users, through: :likes, source: :user
+
   validates :user_id, presence: true
   validates :content, presence: true
+
 end

--- a/api-and-rspec-training/app/models/user.rb
+++ b/api-and-rspec-training/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
+  has_many :likes, dependent: :destroy
+  has_many :liked_posts, through: :likes, source: :post
 
   validates :username, presence: true, uniqueness: true
   has_secure_password

--- a/api-and-rspec-training/config/routes.rb
+++ b/api-and-rspec-training/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   namespace :api do
     post "login", to: "sessions#create"
     resources :users, only: [:show]
-    resources :posts, only: [:index, :show, :create]
+    resources :posts, only: [:index, :show, :create] do
+      resource :like, only: [:create]
+    end
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/api-and-rspec-training/db/migrate/20241106132149_create_likes.rb
+++ b/api-and-rspec-training/db/migrate/20241106132149_create_likes.rb
@@ -1,0 +1,10 @@
+class CreateLikes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/api-and-rspec-training/db/migrate/20241106145917_add_unique_index_to_likes.rb
+++ b/api-and-rspec-training/db/migrate/20241106145917_add_unique_index_to_likes.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToLikes < ActiveRecord::Migration[7.2]
+  def change
+    add_index :likes, [:user_id, :post_id], unique: true, name: 'index_likes_on_user_id_and_post_id'
+  end
+end

--- a/api-and-rspec-training/db/schema.rb
+++ b/api-and-rspec-training/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_06_132149) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_06_145917) do
   create_table "likes", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "post_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 

--- a/api-and-rspec-training/db/schema.rb
+++ b/api-and-rspec-training/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_04_051330) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_06_132149) do
+  create_table "likes", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.text "content", null: false
     t.integer "user_id", null: false
@@ -28,5 +37,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_04_051330) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
 end

--- a/api-and-rspec-training/spec/factories/likes.rb
+++ b/api-and-rspec-training/spec/factories/likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :like do
+    user { nil }
+    post { nil }
+  end
+end

--- a/api-and-rspec-training/spec/factories/users.rb
+++ b/api-and-rspec-training/spec/factories/users.rb
@@ -2,5 +2,10 @@ FactoryBot.define do
   factory :user do
     username { "testuser" }
     password { "password" }
+
+    trait :other_user do
+      username { "otheruser" }
+      password { "otherpassword" }
+    end
   end
 end

--- a/api-and-rspec-training/spec/models/like_spec.rb
+++ b/api-and-rspec-training/spec/models/like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/api-and-rspec-training/spec/requests/api/likes_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/likes_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Likes", type: :request do
+  
+end

--- a/api-and-rspec-training/spec/requests/api/likes_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/likes_spec.rb
@@ -1,5 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe "Api::Likes", type: :request do
-  
+  let!(:user) { FactoryBot.create(:user)}
+  let!(:other_user_id) { 9999 }
+  let!(:other_user_post_id) { 9999 }
+
+  describe "POST /api/posts/{post_id}/like" do
+    context "セッションで認証されている場合" do
+      before do
+        post "/api/login", params: { username: user.username, password: user.password }  # 事前にログインをしておく
+      end
+
+      it "投稿に対していいねができる" do
+        user_post = FactoryBot.create(:post, user: user)
+        post "/api/posts/#{user_post.id}/like"
+
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response["message"]).to eq("いいねしました。")
+      end
+
+      it "重複していいねした場合、ステータスは422でエラーメッセージを返す" do
+        user_post = FactoryBot.create(:post, user: user)
+        post "/api/posts/#{user_post.id}/like"  # 最初の「いいね」
+        post "/api/posts/#{user_post.id}/like"  # 2回目の「いいね」
+    
+        expect(response).to have_http_status(:unprocessable_entity)
+        json_response = JSON.parse(response.body)
+        expect(json_response["error"]).to eq("すでにいいね済みです。")
+      end
+    end
+
+    context "セッションで認証されていない場合" do
+      let!(:user_post) { FactoryBot.create(:post, user: user)}
+      it "ステータスは401で認証エラーメッセージを返す" do
+        post "/api/posts/#{user_post.id}/like"
+    
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to eq("error" => "認証されていないアクセスです。")
+      end
+    end
+  end
 end

--- a/api-and-rspec-training/spec/requests/api/likes_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/likes_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Api::Likes", type: :request do
   let!(:user) { FactoryBot.create(:user)}
-  let!(:other_user_id) { 9999 }
-  let!(:other_user_post_id) { 9999 }
+  let!(:other_user) { FactoryBot.create(:user, :other_user) }
 
   describe "POST /api/posts/{post_id}/like" do
     context "セッションで認証されている場合" do
@@ -11,7 +10,16 @@ RSpec.describe "Api::Likes", type: :request do
         post "/api/login", params: { username: user.username, password: user.password }  # 事前にログインをしておく
       end
 
-      it "投稿に対していいねができる" do
+      it "他の人の投稿に対していいねができる" do
+        other_user_post = FactoryBot.create(:post, user: other_user)
+        post "/api/posts/#{other_user_post.id}/like"
+
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response["message"]).to eq("いいねしました。")
+      end
+
+      it "自分の投稿に対していいねができる" do
         user_post = FactoryBot.create(:post, user: user)
         post "/api/posts/#{user_post.id}/like"
 
@@ -21,20 +29,31 @@ RSpec.describe "Api::Likes", type: :request do
       end
 
       it "重複していいねした場合、ステータスは422でエラーメッセージを返す" do
-        user_post = FactoryBot.create(:post, user: user)
-        post "/api/posts/#{user_post.id}/like"  # 最初の「いいね」
-        post "/api/posts/#{user_post.id}/like"  # 2回目の「いいね」
+        other_user_post = FactoryBot.create(:post, user: other_user)
+        post "/api/posts/#{other_user_post.id}/like"  # 最初の「いいね」
+        post "/api/posts/#{other_user_post.id}/like"  # 2回目の「いいね」
     
         expect(response).to have_http_status(:unprocessable_entity)
         json_response = JSON.parse(response.body)
         expect(json_response["error"]).to eq("すでにいいね済みです。")
       end
+
+      it "存在しない投稿の場合、ステータスは404でエラーメッセージを返す" do
+        invalid_post_id = 9999
+        post "/api/posts/#{invalid_post_id}/like"
+
+        expect(response).to have_http_status(:not_found)
+        json_response = JSON.parse(response.body)
+        expect(json_response["error"]).to eq("該当する投稿が見つかりませんでした。")
+      end
+
+      
     end
 
     context "セッションで認証されていない場合" do
-      let!(:user_post) { FactoryBot.create(:post, user: user)}
       it "ステータスは401で認証エラーメッセージを返す" do
-        post "/api/posts/#{user_post.id}/like"
+        other_user_post = FactoryBot.create(:post, user: other_user)
+        post "/api/posts/#{other_user_post.id}/like"
     
         expect(response).to have_http_status(:unauthorized)
         expect(JSON.parse(response.body)).to eq("error" => "認証されていないアクセスです。")


### PR DESCRIPTION
下記手順で実装いたしました。

1. LikeモデルとLikesコントローラーの作成、ルーティングの設定、
2. データベースにLikeテーブルを作成し、リレーションの設定
3. post_idから該当の投稿を取得し、likeテーブルに保存
4. 重複したいいねができないようにバリデーションの追加、データベース制約でuser_idとpost_idを使い一意の制約を追加
5. テストを作成

■ テストケース
▼ セッションで認証されている場合
他の人の投稿に対していいねができる
自分の投稿に対していいねができる
重複していいねした場合、ステータスは422でエラーメッセージを返す
存在しない投稿の場合、ステータスは404でエラーメッセージを返す

▼ セッションで認証されていない場合
ステータスは401で認証エラーメッセージを返す