### PR TITLE
POST /api/posts/{id}/commentsの作成とテストの作成

### DIFF
--- a/api-and-rspec-training/app/controllers/api/comments_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/comments_controller.rb
@@ -1,0 +1,5 @@
+class Api::CommentsController < ApplicationController
+  def create
+    
+  end
+end

--- a/api-and-rspec-training/app/controllers/api/comments_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/comments_controller.rb
@@ -1,6 +1,13 @@
 class Api::CommentsController < ApplicationController
   before_action :authenticate_user! # セッションを保持しているかアクションの前に確認
 
+  # 例外処理 JSON以外のリクエストが来たときの場合
+  rescue_from ActionDispatch::Http::Parameters::ParseError, with: :handle_parse_error
+  # 例外処理 パラメータが不正なリクエストの場合（requireで指定してるパラメータ）
+  rescue_from ActionController::ParameterMissing, with: :handle_parameter_missing
+  # 例外処理（findは、値が取得できなかった場合にActiveRecord::RecordNotFoundを返す）
+  rescue_from ActiveRecord::RecordNotFound, with: :handle_record_not_found
+
   def create
     if comment_params[:content].blank?
       return render json: { error: "コメントが空です。" }, status: :unprocessable_entity

--- a/api-and-rspec-training/app/controllers/api/comments_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/comments_controller.rb
@@ -1,4 +1,6 @@
 class Api::CommentsController < ApplicationController
+  before_action :authenticate_user! # セッションを保持しているかアクションの前に確認
+
   def create
     if comment_params[:content].blank?
       return render json: { error: "コメントが空です。" }, status: :unprocessable_entity

--- a/api-and-rspec-training/app/controllers/api/comments_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/comments_controller.rb
@@ -1,5 +1,23 @@
 class Api::CommentsController < ApplicationController
   def create
-    
+    if comment_params[:content].blank?
+      return render json: { error: "コメントが空です。" }, status: :unprocessable_entity
+    end
+
+    post = Post.find(params[:post_id])
+    comment = post.comments.build(comment_params)
+    comment.user = current_user
+
+    if comment.save
+      render json: comment, status: :ok
+    else
+      render json: { error: "コメントができませんでした。"}, status: :unprocessable_entity
+    end
   end
+
+  private
+
+    def comment_params
+      params.require(:comment).permit(:content)
+    end
 end

--- a/api-and-rspec-training/app/controllers/api/posts_controller.rb
+++ b/api-and-rspec-training/app/controllers/api/posts_controller.rb
@@ -3,7 +3,7 @@ class Api::PostsController < ApplicationController
 
   # 例外処理 JSON以外のリクエストが来たときの場合
   rescue_from ActionDispatch::Http::Parameters::ParseError, with: :handle_parse_error
-  # 例外処理 パラメータが不正なリクエストの場合
+  # 例外処理 パラメータが不正なリクエストの場合（requireで指定してるパラメータ）
   rescue_from ActionController::ParameterMissing, with: :handle_parameter_missing
   # 例外処理（findは、値が取得できなかった場合にActiveRecord::RecordNotFoundを返す）
   rescue_from ActiveRecord::RecordNotFound, with: :handle_record_not_found
@@ -38,17 +38,5 @@ class Api::PostsController < ApplicationController
 
     def post_params
       params.require(:post).permit(:content)
-    end
-
-    def handle_parse_error(exception)
-      render json: { error: "リクエストはJSON形式である必要があります。" }, status: :bad_request
-    end
-
-    def handle_parameter_missing(exception)
-      render json: { error: "不正なリクエストであるため、投稿できませんでした。" }, status: :unprocessable_entity
-    end
-
-    def handle_record_not_found(exception)
-      render json: { error: "該当する投稿が見つかりませんでした。" }, status: :not_found
     end
 end

--- a/api-and-rspec-training/app/controllers/application_controller.rb
+++ b/api-and-rspec-training/app/controllers/application_controller.rb
@@ -14,4 +14,24 @@ class ApplicationController < ActionController::API
       @current_user ||= User.find_by(id: user_id) # find_byを実行するまでに、すでに@current_userに値がないが確認し、値があればそれを返す。
     end
   end
+
+  def handle_parse_error(exception)
+    render json: { error: "リクエストはJSON形式である必要があります。" }, status: :bad_request
+  end
+
+  def handle_parameter_missing(exception)
+    render json: { error: "不正なリクエストであるため、保存できませんでした。" }, status: :unprocessable_entity
+  end
+
+  def handle_record_not_found(exception)
+    error_message = case exception.model
+    when "Post"
+      "該当する投稿が見つかりませんでした。"
+    when "Comment"
+      "該当するコメントが見つかりませんでした。"
+    else
+      "該当するレコードが見つかりませんでした。"
+    end
+    render json: { error: error_message }, status: :not_found
+  end
 end

--- a/api-and-rspec-training/app/models/comment.rb
+++ b/api-and-rspec-training/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+end

--- a/api-and-rspec-training/app/models/comment.rb
+++ b/api-and-rspec-training/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
+
+  validates :content, presence: true  # コメント内容の必須バリデーション
 end

--- a/api-and-rspec-training/app/models/post.rb
+++ b/api-and-rspec-training/app/models/post.rb
@@ -2,7 +2,7 @@ class Post < ApplicationRecord
   belongs_to :user
   has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
-  has_many :comments, dependent: :destory
+  has_many :comments, dependent: :destroy
 
   validates :user_id, presence: true
   validates :content, presence: true

--- a/api-and-rspec-training/app/models/post.rb
+++ b/api-and-rspec-training/app/models/post.rb
@@ -2,6 +2,7 @@ class Post < ApplicationRecord
   belongs_to :user
   has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
+  has_many :comments, dependent: :destory
 
   validates :user_id, presence: true
   validates :content, presence: true

--- a/api-and-rspec-training/app/models/user.rb
+++ b/api-and-rspec-training/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :likes, dependent: :destroy
-  has_many :liked_posts, through: :likes, source: :post
+  has_many :comments, dependent: :destroy
 
   validates :username, presence: true, uniqueness: true
   has_secure_password

--- a/api-and-rspec-training/config/routes.rb
+++ b/api-and-rspec-training/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     resources :users, only: [:show]
     resources :posts, only: [:index, :show, :create] do
       resource :like, only: [:create]
+      resource :comments, only: [:create]
     end
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/api-and-rspec-training/db/migrate/20241106161749_create_comments.rb
+++ b/api-and-rspec-training/db/migrate/20241106161749_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.2]
+  def change
+    create_table :comments do |t|
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/api-and-rspec-training/db/schema.rb
+++ b/api-and-rspec-training/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_06_145917) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_06_161749) do
+  create_table "comments", force: :cascade do |t|
+    t.text "content", null: false
+    t.integer "user_id", null: false
+    t.integer "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "likes", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "post_id", null: false
@@ -38,6 +48,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_06_145917) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"

--- a/api-and-rspec-training/spec/factories/comments.rb
+++ b/api-and-rspec-training/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    content { "MyText" }
+    user { nil }
+    post { nil }
+  end
+end

--- a/api-and-rspec-training/spec/factories/comments.rb
+++ b/api-and-rspec-training/spec/factories/comments.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :comment do
-    content { "MyText" }
+    content { Faker::Lorem.paragraph(sentence_count: 10) }
     user { nil }
     post { nil }
   end

--- a/api-and-rspec-training/spec/models/comment_spec.rb
+++ b/api-and-rspec-training/spec/models/comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/api-and-rspec-training/spec/requests/api/comments_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/comments_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Comments", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/api-and-rspec-training/spec/requests/api/comments_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/comments_spec.rb
@@ -1,7 +1,66 @@
 require 'rails_helper'
 
 RSpec.describe "Api::Comments", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let!(:user) { FactoryBot.create(:user)}
+  let!(:other_user) { FactoryBot.create(:user, :other_user) }
+
+  describe "POST /api/posts/{post_id}/comments" do
+    context "セッションで認証されている場合" do
+      before do
+        post "/api/login", params: { username: user.username, password: user.password }  # 事前にログインをしておく
+      end
+
+      it "他の人の投稿に対して正常にコメントができた場合、ステータスは200で投稿したコメントを返す" do
+        other_user_post = FactoryBot.create(:post, user: other_user)
+        user_comment = FactoryBot.build(:comment, user: user, post:other_user_post)
+        post "/api/posts/#{other_user_post.id}/comments", params: { comment: { content: user_comment.content } }
+
+        expect(user_comment).to be_valid
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to have_key("id")
+        expect(json_response["content"]).to eq(user_comment.content)
+      end
+
+      it "コメントのcontentが空のリクエストの場合、422ステータスを返し、エラーメッセージを返す" do
+        other_user_post = FactoryBot.create(:post, user: other_user)
+        invalid_user_comment = FactoryBot.build(:comment, content: nil, user: user, post:other_user_post)
+        post "/api/posts/#{other_user_post.id}/comments", params: { comment: { content: invalid_user_comment.content } }
+
+        expect(invalid_user_comment).not_to be_valid
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to eq("error" => "コメントが空です。")
+      end
+
+      it "空のcommentオブジェクトを送信した場合、422ステータスを返し、エラーメッセージを返す" do
+        other_user_post = FactoryBot.create(:post, user: other_user)
+        post "/api/posts/#{other_user_post.id}/comments", params: { comment: {} }
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to eq("error" => "不正なリクエストであるため、保存できませんでした。")
+      end
+
+      it "不正なキーでリクエストした場合、422ステータスを返し、エラーメッセージを返す" do
+        other_user_post = FactoryBot.create(:post, user: other_user)
+        post "/api/posts/#{other_user_post.id}/comments", params: { invalid_key: { content: "Content" } }
+  
+        expect(response).to have_http_status(:unprocessable_entity)
+        json_response = JSON.parse(response.body)
+        expect(json_response).to eq("error" => "不正なリクエストであるため、保存できませんでした。")
+      end
+    end
+    context "セッションで認証されていない場合" do
+      it "ステータスは401で認証エラーメッセージを返す" do
+        other_user_post = FactoryBot.create(:post, user: other_user)
+        post "/api/posts/#{other_user_post.id}/comments", params: { content: "テストコメントです" }
+    
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to eq("error" => "認証されていないアクセスです。")
+      end
+    end
   end
 end

--- a/api-and-rspec-training/spec/requests/api/posts_spec.rb
+++ b/api-and-rspec-training/spec/requests/api/posts_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Api::Posts", type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
 
         json_response = JSON.parse(response.body)
-        expect(json_response).to eq("error" => "不正なリクエストであるため、投稿できませんでした。")
+        expect(json_response).to eq("error" => "不正なリクエストであるため、保存できませんでした。")
       end
 
       it "不正なキーでリクエストした場合、422ステータスを返し、エラーメッセージを返す" do
@@ -119,7 +119,7 @@ RSpec.describe "Api::Posts", type: :request do
   
         expect(response).to have_http_status(:unprocessable_entity)
         json_response = JSON.parse(response.body)
-        expect(json_response).to eq("error" => "不正なリクエストであるため、投稿できませんでした。")
+        expect(json_response).to eq("error" => "不正なリクエストであるため、保存できませんでした。")
       end
     end
 
@@ -131,7 +131,5 @@ RSpec.describe "Api::Posts", type: :request do
         expect(JSON.parse(response.body)).to eq("error" => "認証されていないアクセスです。")
       end
     end
-
-
   end
 end


### PR DESCRIPTION
下記手順で実装いたしました。

1. CommentモデルとCommentsコントローラーを作成、ルーティングを設定
2. post_idから該当する投稿を取得し、commentのインスタンスを作成
3. commentにuser_idを登録し、だれがコメントしたかを紐づける
4. commentをDBに保存と保存できなかった処理を作成
5. 正常系のテストを作成
6. 例外処理を作成
7. 例外処理に沿ってテストを追加

■ テストケース
▼ セッションで認証されている場合
- 他の人の投稿に対して正常にコメントができた場合、ステータスは200で投稿したコメントを返す
- コメントのcontentが空のリクエストの場合、422ステータスを返し、エラーメッセージを返す
- 空のcommentオブジェクトを送信した場合、422ステータスを返し、エラーメッセージを返す
- 不正なキーでリクエストした場合、422ステータスを返し、エラーメッセージを返す

▼ セッションで認証されていない場合
ステータスは401で認証エラーメッセージを返す